### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
           ref: "main"
 
 #      - name: Publish to Registry
-#        uses: elgohr/Publish-Docker-Github-Action@master
+#        uses: elgohr/Publish-Docker-Github-Action@v5
 #        with:
 #          name: easonchen147/ginson
 #          username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore